### PR TITLE
Update base URL to met the new requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea


### PR DESCRIPTION
> To access data from outside the Amazon cloud, via HTTP(S), the new URL prefix https://data.commoncrawl.org/ – must be used.

https://web.archive.org/web/20240711235615/https://commoncrawl.org/get-started

This resolves #1 